### PR TITLE
Fixed config.properties for controls-fx

### DIFF
--- a/drombler-fx-maven-archetype-application/src/main/resources/archetype-resources/__rootArtifactId__-application/src/main/app/conf/config.properties
+++ b/drombler-fx-maven-archetype-application/src/main/resources/archetype-resources/__rootArtifactId__-application/src/main/app/conf/config.properties
@@ -14,6 +14,7 @@
 #com.sun.javafx.scene.control, \
 #com.sun.javafx.scene.control.behavior, \
 #com.sun.javafx.scene.control.skin, \
+#com.sun.javafx.scene.text, \
 #com.sun.javafx.scene.traversal, \
 #com.sun.javafx.tk, \
 #com.sun.javafx.webkit, \


### PR DESCRIPTION
The newer controls-fx library needs an import statement for the `com.sun.scene.text` package. I just added it to the config.properties file.